### PR TITLE
refactor: sitemap locale prefix 하드코딩을 설정을 사용하도록 변경

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -12,7 +12,7 @@ type Href = Parameters<typeof getPathname>[0]['href'];
 
 function getEntries(href: Href) {
   return {
-    url: getUrl(href) + 'en',
+    url: getUrl(href) + routing.defaultLocale,
     alternates: {
       languages: Object.fromEntries(
         routing.locales.map((cur) => [cur, getUrl(href, cur)])


### PR DESCRIPTION
### 개요

sitemap locale prefix 하드코딩을 설정을 사용하도록 변경

### 상세

- 추후에 일부만 변경되어 불일치가 생길 수 있는 가능성을 제거합니다.

### 관련 이슈

- Closes #20 